### PR TITLE
vaule syntax fix for grafana helm chart

### DIFF
--- a/3-2-Monitoring/grafana-values.yaml
+++ b/3-2-Monitoring/grafana-values.yaml
@@ -7,7 +7,8 @@ serviceAccount:
 
 replicas: 1
 
-deploymentStrategy: RollingUpdate
+deploymentStrategy:
+  type: RollingUpdate
 
 readinessProbe:
   httpGet:


### PR DESCRIPTION
refer to https://github.com/helm/charts/blob/master/stable/grafana/values.yaml#L30
without fix the 'deploymentStategy', below error will occur when running 'helm install -f grafana-values.yaml stable/grafana --name grafana --namespace grafana'

` Error: release grafana failed: Deployment in version "v1" cannot be handled as a Deployment: v1.Deployment.Spec: v1.DeploymentSpec.Strategy: readObjectStart: expect { or n, but found ", error found in #10 byte of ...|trategy":"RollingUpd|..., bigger context ...|"app":"grafana","release":"grafana"}},"strategy":"RollingUpdate","template":{"metadata":{"annotation|..`